### PR TITLE
feat: add support for relative access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ deep-docs/
 
 # OCM ctf from e2e test
 ctf
+ctf-rel
 
 # binary in case cmd/ocm-kit was built
 /ocm-kit

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1768495715,
+        "lastModified": 1776537207,
+        "narHash": "sha256-CmDPLGo5rK02AV8d0SegYwQA+6aWPFWym6mYKqOzRT0=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "23729dc54bbca0f36878ae2935cbfea834335f1a",
+        "rev": "878c73c0b232d47b5fb79b4c6dbc2cdf3aaa3f76",
         "type": "github"
       },
       "original": {
@@ -20,6 +21,7 @@
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "NixOS",
         "repo": "flake-compat",
         "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
@@ -34,14 +36,15 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1767039857,
-        "owner": "NixOS",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "edolstra",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -51,10 +54,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1731533236,
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -69,6 +73,7 @@
       },
       "locked": {
         "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
@@ -87,10 +92,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1767281941,
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f0927703b7b1c8d97511c4116eb9b4ec6645a0fa",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
         "type": "github"
       },
       "original": {
@@ -109,10 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769939035,
+        "lastModified": 1765016596,
+        "narHash": "sha256-rhSqPNxDVow7OQKi4qS5H8Au0P4S3AYbawBSmJNUtBQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "a8ca480175326551d6c4121498316261cbb5b260",
+        "rev": "548fc44fca28a5e81c5d6b846e555e6b9c2a5a3c",
         "type": "github"
       },
       "original": {
@@ -129,10 +136,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762808025,
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -150,10 +158,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762808025,
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -171,10 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770221620,
+        "lastModified": 1776607327,
+        "narHash": "sha256-AB6WHQ0WZfRegTjVR3RHX6sgcMtiJ7/AVm6cOl57KQE=",
         "owner": "purpleclay",
         "repo": "go-overlay",
-        "rev": "64abb783f24771bf58d0f7196348bd4c56a5308f",
+        "rev": "cefd4b095ad5ff674cca803ac5b1747f92455fb4",
         "type": "github"
       },
       "original": {
@@ -189,10 +199,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1767019875,
+        "lastModified": 1770585520,
+        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
         "owner": "nix-community",
         "repo": "gomod2nix",
-        "rev": "49662a44272806ff785df2990a420edaaca15db4",
+        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
         "type": "github"
       },
       "original": {
@@ -203,10 +214,28 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768395095,
+        "lastModified": 1770073757,
+        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13868c071cc73a5e9f610c47d7bb08e5da64fdd5",
+        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -218,10 +247,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1768305791,
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {
@@ -233,10 +263,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1768563902,
+        "lastModified": 1755864489,
+        "narHash": "sha256-ojoEEg2c8gTyV+9sZzPWiMgtsXoqTkY/8k7tEqn9TQo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "81a91f17b4aac8ce4a281ee5b390bd36cf51bc98",
+        "rev": "f24c0439ea1296e295445e0d8117d282bdacaa9a",
         "type": "github"
       },
       "original": {
@@ -247,11 +278,15 @@
       }
     },
     "nixpkgs_3": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
       "locked": {
-        "lastModified": 1767052823,
+        "lastModified": 1776348333,
+        "narHash": "sha256-ZyrYhlLGGuN5ieW7pE65meJJYnNz5el9vJtGBEJyDMQ=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "538a5124359f0b3d466e1160378c87887e3b51a4",
+        "rev": "efff47329167854ce48541c7ef731bf120753c7e",
         "type": "github"
       },
       "original": {
@@ -268,15 +303,13 @@
         "go-overlay": "go-overlay",
         "gomod": "gomod",
         "nixpkgs": "nixpkgs_3",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ]
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {
       "locked": {
         "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
         "repo": "default",
         "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
@@ -291,6 +324,7 @@
     "systems_2": {
       "locked": {
         "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
         "repo": "default",
         "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",

--- a/helmvalues/helmvalues.go
+++ b/helmvalues/helmvalues.go
@@ -15,6 +15,7 @@ import (
 	"ocm.software/ocm/api/ocm/compdesc"
 	v1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
 	"ocm.software/ocm/api/ocm/extensions/accessmethods/ociartifact"
+	"ocm.software/ocm/api/ocm/extensions/accessmethods/relativeociref"
 	"sigs.k8s.io/yaml"
 )
 
@@ -196,24 +197,26 @@ func GetRenderingInput(compVer ocm.ComponentVersionAccess) (*RenderingInput, err
 	ociResourceMap := make(map[string]ImageReference)
 
 	for _, res := range compVer.GetResources() {
-		ga := res.GlobalAccess()
-		if ga == nil {
-			continue
+		imageRef, err := resolveOCIReference(res, compVer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve OCI reference for resource %s: %w", res.Meta().Name, err)
 		}
-		spec, ok := ga.(*ociartifact.AccessSpec)
-		if !ok {
+
+		if imageRef == "" {
 			continue
 		}
 
 		// Parse OCI reference and store it
-		parsedRef, err := ParseOCIRef(spec.ImageReference)
+		parsedRef, err := ParseOCIRef(imageRef)
 		if err != nil {
 			return nil, fmt.Errorf("resources access contained invalid image reference: %w", err)
 		}
+
 		digest := ""
 		if parsedRef.Digest != nil {
 			digest = string(*parsedRef.Digest)
 		}
+
 		ociResourceMap[res.Meta().Name] = ImageReference{
 			Host:       parsedRef.Host,
 			Repository: parsedRef.Repository,
@@ -226,6 +229,38 @@ func GetRenderingInput(compVer ocm.ComponentVersionAccess) (*RenderingInput, err
 		OCIResources: ociResourceMap,
 		Component:    componentSpec,
 	}, nil
+}
+
+// resolveOCIReference extracts the OCI image reference from a resource access.
+// It handles both absolute references (ociArtifact) via GlobalAccess and relative
+// references (relativeOciReference) by resolving them against the component version's
+// repository.
+func resolveOCIReference(res ocm.ResourceAccess, compVer ocm.ComponentVersionAccess) (string, error) {
+	// Try global access first — works for absolute ociArtifact references.
+	ga := res.GlobalAccess()
+	if ga != nil {
+		if spec, ok := ga.(*ociartifact.AccessSpec); ok {
+			return spec.ImageReference, nil
+		}
+	}
+
+	// Fall back to checking the local access spec for relative OCI references.
+	acc, err := res.Access()
+	if err != nil {
+		return "", fmt.Errorf("failed to get access spec: %w", err)
+	}
+
+	if relSpec, ok := acc.(*relativeociref.AccessSpec); ok {
+		ref, err := relSpec.GetOCIReference(compVer)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve relative OCI reference: %w", err)
+		}
+
+		return ref, nil
+	}
+
+	// Not an OCI-based resource — skip it.
+	return "", nil
 }
 
 // Render processes a Helm values template with the provided rendering input.

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -102,6 +102,54 @@ else
 	exit 1
 fi
 
+# Transfer with preferRelativeAccess for tests 3 and 4
+REL_VERSION="${VERSION}-rel"
+REL_CTF_DIR="${SCRIPT_DIR}/fixtures/arc/ctf-rel"
+REL_ARTIFACT_INDEX="${REL_CTF_DIR}/artifact-index.json"
+
+if [ ! -f "$REL_ARTIFACT_INDEX" ] || ! grep -q "\"tag\":\"${REL_VERSION}\"" "$REL_ARTIFACT_INDEX"; then
+	echo "Creating and transferring component version ${REL_VERSION} with relative access..."
+	rm -rf "${REL_CTF_DIR}"
+	(cd "$SCRIPT_DIR/fixtures/arc" && ${OCM} add componentversion --version "${REL_VERSION}" --create --file ./ctf-rel component-constructor.yaml)
+	${OCM} --config "$SCRIPT_DIR/fixtures/ocmconfig-relative-access.yaml" transfer ctf --copy-resources "${REL_CTF_DIR}" http://localhost:5000/my-components
+else
+	echo "Component version ${REL_VERSION} already exists in CTF"
+fi
+
+# Test 3: Render default template with relative access
+echo "Test 3: Rendering default Helm values template (relative access)..."
+OUTPUT3=$(${GO} run cmd/ocm-kit/main.go "http://localhost:5000/my-components//opendefense.cloud/arc:${REL_VERSION}" -r helm-chart)
+if echo "$OUTPUT3" | grep -q "apiserver:" && \
+   echo "$OUTPUT3" | grep -q "controller:" && \
+   echo "$OUTPUT3" | grep -q "etcd:" && \
+   echo "$OUTPUT3" | grep -q "localhost:5000/my-components/opendefensecloud/arc-apiserver" && \
+   echo "$OUTPUT3" | grep -q "localhost:5000/my-components/opendefensecloud/arc-controller-manager" && \
+   echo "$OUTPUT3" | grep -q "localhost:5000/my-components/coreos/etcd"; then
+	echo "✓ Test 3 passed: Default template rendered correctly with relative access"
+else
+	echo "✗ Test 3 failed: Default template with relative access output missing expected content"
+	echo "Output was:"
+	echo "$OUTPUT3"
+	exit 1
+fi
+
+# Test 4: Render override template with relative access
+echo "Test 4: Rendering override Helm values template (relative access)..."
+OUTPUT4=$(${GO} run cmd/ocm-kit/main.go "http://localhost:5000/my-components//opendefense.cloud/arc:${REL_VERSION}" -r helm-chart --local-helm-values-template "$SCRIPT_DIR/fixtures/arc/override-values.yaml.tpl")
+if echo "$OUTPUT4" | grep -q "foobar:" && \
+   echo "$OUTPUT4" | grep -q "fizzbuzz:" && \
+   echo "$OUTPUT4" | grep -q "helloworld:" && \
+   echo "$OUTPUT4" | grep -q "localhost:5000/my-components/opendefensecloud/arc-apiserver" && \
+   echo "$OUTPUT4" | grep -q "localhost:5000/my-components/opendefensecloud/arc-controller-manager" && \
+   echo "$OUTPUT4" | grep -q "localhost:5000/my-components/coreos/etcd"; then
+	echo "✓ Test 4 passed: Override template rendered correctly with relative access"
+else
+	echo "✗ Test 4 failed: Override template with relative access output missing expected content"
+	echo "Output was:"
+	echo "$OUTPUT4"
+	exit 1
+fi
+
 # Cleanup only if --keep-zot was not provided
 if [ "$KEEP_ZOT" = false ]; then
 	echo "Stopping zot registry..."

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -106,6 +106,7 @@ fi
 REL_VERSION="${VERSION}-rel"
 REL_CTF_DIR="${SCRIPT_DIR}/fixtures/arc/ctf-rel"
 REL_ARTIFACT_INDEX="${REL_CTF_DIR}/artifact-index.json"
+REL_ACCESS_HOST="${REL_ACCESS_HOST:-127.0.0.1:5000}"
 
 if [ ! -f "$REL_ARTIFACT_INDEX" ] || ! grep -q "\"tag\":\"${REL_VERSION}\"" "$REL_ARTIFACT_INDEX"; then
 	echo "Creating and transferring component version ${REL_VERSION} with relative access..."
@@ -118,13 +119,13 @@ fi
 
 # Test 3: Render default template with relative access
 echo "Test 3: Rendering default Helm values template (relative access)..."
-OUTPUT3=$(${GO} run cmd/ocm-kit/main.go "http://localhost:5000/my-components//opendefense.cloud/arc:${REL_VERSION}" -r helm-chart)
+OUTPUT3=$(${GO} run cmd/ocm-kit/main.go "http://${REL_ACCESS_HOST}/my-components//opendefense.cloud/arc:${REL_VERSION}" -r helm-chart)
 if echo "$OUTPUT3" | grep -q "apiserver:" && \
    echo "$OUTPUT3" | grep -q "controller:" && \
    echo "$OUTPUT3" | grep -q "etcd:" && \
-   echo "$OUTPUT3" | grep -q "localhost:5000/my-components/opendefensecloud/arc-apiserver" && \
-   echo "$OUTPUT3" | grep -q "localhost:5000/my-components/opendefensecloud/arc-controller-manager" && \
-   echo "$OUTPUT3" | grep -q "localhost:5000/my-components/coreos/etcd"; then
+   echo "$OUTPUT3" | grep -Fq "${REL_ACCESS_HOST}/my-components/opendefensecloud/arc-apiserver" && \
+   echo "$OUTPUT3" | grep -Fq "${REL_ACCESS_HOST}/my-components/opendefensecloud/arc-controller-manager" && \
+   echo "$OUTPUT3" | grep -Fq "${REL_ACCESS_HOST}/my-components/coreos/etcd"; then
 	echo "✓ Test 3 passed: Default template rendered correctly with relative access"
 else
 	echo "✗ Test 3 failed: Default template with relative access output missing expected content"
@@ -135,13 +136,13 @@ fi
 
 # Test 4: Render override template with relative access
 echo "Test 4: Rendering override Helm values template (relative access)..."
-OUTPUT4=$(${GO} run cmd/ocm-kit/main.go "http://localhost:5000/my-components//opendefense.cloud/arc:${REL_VERSION}" -r helm-chart --local-helm-values-template "$SCRIPT_DIR/fixtures/arc/override-values.yaml.tpl")
+OUTPUT4=$(${GO} run cmd/ocm-kit/main.go "http://${REL_ACCESS_HOST}/my-components//opendefense.cloud/arc:${REL_VERSION}" -r helm-chart --local-helm-values-template "$SCRIPT_DIR/fixtures/arc/override-values.yaml.tpl")
 if echo "$OUTPUT4" | grep -q "foobar:" && \
    echo "$OUTPUT4" | grep -q "fizzbuzz:" && \
    echo "$OUTPUT4" | grep -q "helloworld:" && \
-   echo "$OUTPUT4" | grep -q "localhost:5000/my-components/opendefensecloud/arc-apiserver" && \
-   echo "$OUTPUT4" | grep -q "localhost:5000/my-components/opendefensecloud/arc-controller-manager" && \
-   echo "$OUTPUT4" | grep -q "localhost:5000/my-components/coreos/etcd"; then
+   echo "$OUTPUT4" | grep -Fq "${REL_ACCESS_HOST}/my-components/opendefensecloud/arc-apiserver" && \
+   echo "$OUTPUT4" | grep -Fq "${REL_ACCESS_HOST}/my-components/opendefensecloud/arc-controller-manager" && \
+   echo "$OUTPUT4" | grep -Fq "${REL_ACCESS_HOST}/my-components/coreos/etcd"; then
 	echo "✓ Test 4 passed: Override template rendered correctly with relative access"
 else
 	echo "✗ Test 4 failed: Override template with relative access output missing expected content"

--- a/test/fixtures/ocmconfig-relative-access.yaml
+++ b/test/fixtures/ocmconfig-relative-access.yaml
@@ -1,0 +1,4 @@
+type: generic.config.ocm.software/v1
+configurations:
+  - type: oci.uploader.config.ocm.software
+    preferRelativeAccess: true


### PR DESCRIPTION

For use-cases where the registry has multiple endpoints in split horizon network setups, we need relative access.
(This will fix issues with ocm-kit in our e2e tests.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for resolving relative OCI artifact references alongside absolute references; added preference option for relative access.
  * New test fixture enabling relative-access scenarios.

* **Tests**
  * Added end-to-end tests validating Helm values rendering with relative access using default and custom chart templates.

* **Chores**
  * Updated ignore rules to exclude ctf-rel artifacts from source control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->