### PR TITLE
chore: add commitlint for conventional commits

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,15 @@
+extends:
+  - "@commitlint/config-conventional"
+rules:
+  type-enum:
+    - 2
+    - always
+    - - feat
+      - fix
+      - docs
+      - chore
+      - refactor
+      - test
+      - ci
+      - perf
+      - revert

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,41 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            ci
+            perf
+            revert
+          requireScope: false
+
+  commitlint:
+    name: Commit Messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: .commitlintrc.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+## Commit Convention
+
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification. Both PR titles and individual commit messages are validated in CI.
+
+### Format
+
+```
+<type>(optional scope): <description>
+```
+
+### Allowed Types
+
+| Type       | Purpose                                              |
+| ---------- | ---------------------------------------------------- |
+| `feat`     | A new feature                                        |
+| `fix`      | A bug fix                                            |
+| `docs`     | Documentation changes                                |
+| `chore`    | Maintenance tasks (deps, CI config, etc.)            |
+| `refactor` | Code changes that neither fix a bug nor add a feature |
+| `test`     | Adding or updating tests                             |
+| `ci`       | CI/CD pipeline changes                               |
+| `perf`     | Performance improvements                             |
+| `revert`   | Reverting a previous commit                          |
+
+### Examples
+
+```
+feat: add OCI artifact signing support
+fix(registry): handle missing manifest digest
+docs: update contributing guidelines
+chore(deps): update cosign to v2.5.0
+refactor(transfer): extract blob streaming logic
+```
+
+### Breaking Changes
+
+Append `!` after the type/scope to indicate a breaking change:
+
+```
+feat!: change artifact transfer API
+refactor(api)!: rename TransferPolicy to SyncPolicy
+```

--- a/flake.lock
+++ b/flake.lock
@@ -15,11 +15,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777018789,
-        "narHash": "sha256-zPYQuLwrMwlYyFAG3aiTta65xaZglt9YSS6/ploHXaY=",
+        "lastModified": 1777472486,
+        "narHash": "sha256-SqeEH+7j6wvWLXn6bzpckEXHiJXjwx2VhT+oIgj0dPw=",
         "owner": "opendefensecloud",
         "repo": "dev-kit",
-        "rev": "8158d30fafe63a596db9b6fe2680b7c72b1a8cc4",
+        "rev": "98ce0218949e5f406658070b6076fb927cdfd229",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776919902,
-        "narHash": "sha256-ndo8Ca96g6XNg4uTlomWuf2R9nd5W+6d0/fEWNie69I=",
+        "lastModified": 1777835412,
+        "narHash": "sha256-bNd8ZYXlo0IXik1DyEOxL3aS01HaDoNc5AqSj1MAGY8=",
         "owner": "purpleclay",
         "repo": "go-overlay",
-        "rev": "957454a0dde6ffcaf14d4a792f061d7dce903258",
+        "rev": "8dc99d1095203caca2e6feab611eb83ca9bdd07b",
         "type": "github"
       },
       "original": {
@@ -219,11 +219,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,9 @@
         devShells.default = dev-kit.lib.mkShell {
           inherit system;
           goVersion = "1.26.2";
+          preCommitHooks = {
+            commitlint.enable = true;
+          };
         };
       }
     );


### PR DESCRIPTION
## What
<!-- One sentence summary -->
Add conventional commit linting to ocm-kit.

## Why
<!-- Motivation / problem being solved. Skip if obvious from the linked issue. -->
See https://github.com/opendefensecloud/odd-internal/issues/15

## Testing
<!-- How was this tested? e.g. unit, envtest, manual against vX.Y.Z -->

## Notes for reviewers
<!-- CRD/API changes, RBAC changes, new watches, breaking changes, upgrade path.
     Delete if not applicable. -->

## Checklist
- [x] Tests added/updated
- [ x No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved
