### PR TITLE
chore: release without cgo and strup debug information in binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,19 +38,19 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/}
           COMMIT=$(git rev-parse --short HEAD)
           BUILD_TIME=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-          LDFLAGS="-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildTime=${BUILD_TIME}"
+          LDFLAGS="-w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildTime=${BUILD_TIME}"
 
           # Linux amd64
-          GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o bin/ocm-kit-linux-amd64 ./cmd/ocm-kit
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o bin/ocm-kit-linux-amd64 ./cmd/ocm-kit
 
           # Linux arm64
-          GOOS=linux GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o bin/ocm-kit-linux-arm64 ./cmd/ocm-kit
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o bin/ocm-kit-linux-arm64 ./cmd/ocm-kit
 
           # Darwin amd64
-          GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o bin/ocm-kit-darwin-amd64 ./cmd/ocm-kit
+          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o bin/ocm-kit-darwin-amd64 ./cmd/ocm-kit
 
           # Darwin arm64
-          GOOS=darwin GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o bin/ocm-kit-darwin-arm64 ./cmd/ocm-kit
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o bin/ocm-kit-darwin-arm64 ./cmd/ocm-kit
 
       - name: Create checksums
         run: |


### PR DESCRIPTION
## What
<!-- One sentence summary -->
Closes #35 

## Why
<!-- Motivation / problem being solved. Skip if obvious from the linked issue. -->
We do not need CGO, let's build the binaries properly and also reduce the size by stripping debug symbols.

## Testing
<!-- How was this tested? e.g. unit, envtest, manual against vX.Y.Z -->

## Notes for reviewers
<!-- CRD/API changes, RBAC changes, new watches, breaking changes, upgrade path.
     Delete if not applicable. -->

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the release build process to produce smaller binaries and improve cross-platform portability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->