### PR TITLE
chore: inherit renovate config from shared renovate config repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,52 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "postUpdateOptions": ["gomodTidy"],
-  "packageRules": [
-    {
-      "matchManagers": ["gomod"],
-      "matchDepTypes": ["golang"],
-      "rangeStrategy": "bump"
-    },
-    {
-      "matchDatasources": ["docker", "golang-version"],
-      "matchPackageNames": ["go", "golang"],
-      "groupName": "golang version sync",
-      "groupSlug": "go-version"
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/(^|/)flake\\.nix$/"],
-      "matchStrings": [
-        "goVersion\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
-      ],
-      "depNameTemplate": "go",
-      "datasourceTemplate": "golang-version"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "Makefile"
-      ],
-      "matchStrings": [
-        "DEV_KIT_VERSION := (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "opendefensecloud/dev-kit",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "tools.lock"
-      ],
-      "matchStrings": [
-        "(?<depName>[^\\s]+) (?<packageName>[^@]+)@(?<currentValue>v?[^\\s]+)"
-      ],
-      "versioningTemplate": "semver",
-      "datasourceTemplate": "go"
-    }
+  "extends": [
+    "github>opendefensecloud/renovate-config",
+    "github>opendefensecloud/renovate-config:go"
   ]
 }


### PR DESCRIPTION
## What
Relates to https://github.com/opendefensecloud/odd-internal/issues/32.

## Why
We created a new repo renovate-config with shared Renovate configurations: https://github.com/opendefensecloud/renovate-config/pull/2.

Instead of duplicating the renovate configs in our repos, we start creating shared Renovate configs in there and only keep repo-specific Renovate configs. For ocm-kit, there is no repo-specific Renovate config.

## Testing
After this PR has been merged, I gonna check Renovate's "Dependency Dashboard" ticket for detected dependencies.

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Renovate configuration by consolidating settings into a shared, externally-maintained configuration repository for more consistent dependency management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendefensecloud/ocm-kit/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->