### PR TITLE
ci: harden GitHub workflows

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
         with:
           configFile: .commitlintrc.yml

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -30,6 +30,8 @@ jobs:
       go-version: ${{ steps.get-go-version.outputs.version }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: get-go-version
         id: get-go-version
         run: |
@@ -53,6 +55,8 @@ jobs:
     runs-on: arc-scale-set
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ needs.lint.outputs.go-version }}

--- a/.github/workflows/issues-add-labels.yaml
+++ b/.github/workflows/issues-add-labels.yaml
@@ -1,4 +1,8 @@
 name: Label issues
+
+permissions:
+  contents: read
+
 on:
   issues:
     types:

--- a/.github/workflows/issues-add-to-project.yml
+++ b/.github/workflows/issues-add-to-project.yml
@@ -1,5 +1,8 @@
 name: Add issues to project
 
+permissions:
+  contents: read
+
 on:
   issues:
     types:
@@ -12,6 +15,8 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    # Authenticates with ADD_TO_PROJECT_PAT, so the workflow GITHUB_TOKEN needs no scopes.
+    permissions: {}
     steps:
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: get-go-version
         id: get-go-version
@@ -79,6 +80,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4

--- a/.github/workflows/update-action-pins.yml
+++ b/.github/workflows/update-action-pins.yml
@@ -1,5 +1,8 @@
 name: Update Action Pins
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
## What
Relates to https://github.com/opendefensecloud/odd-internal/issues/40 and https://github.com/opendefensecloud/odd-internal/issues/43.

## Why
Restrict the permissions of our GitHub workflows to follow security best practices.

## Testing
none

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced GitHub Actions workflow security configurations across multiple jobs by restricting credential persistence and implementing granular permission scopes to strengthen pipeline security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->