### PR TITLE
fix: migrate away from abandoned self-hosted runner arc-scale-set

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   lint:
-    runs-on: arc-scale-set
+    runs-on: ubuntu-24.04
     outputs:
       go-version: ${{ steps.get-go-version.outputs.version }}
     steps:
@@ -52,7 +52,7 @@ jobs:
 
   test:
     needs: lint
-    runs-on: arc-scale-set
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:


### PR DESCRIPTION
## What
Migrates to GitHub-hosted runner for Golang CI.

## Why
We delete the self-hosted runner. For some reason this occurrence doesn't show up in the GitHub search: https://github.com/search?q=org%3Aopendefensecloud+arc-scale-set&type=code

## Testing
none

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->