### PR TITLE
chore: run Golang CI GitHub action on Makefile changes

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -11,6 +11,7 @@ on:
       - "flake.nix"
       - "go.mod"
       - "go.sum"
+      - "Makefile"
   pull_request:
     branches: [main, develop]
     paths:
@@ -19,6 +20,7 @@ on:
       - "flake.nix"
       - "go.mod"
       - "go.sum"
+      - "Makefile"
 
 env:
   GO_MODULE: https://github.com/opendefensecloud/ocm-kit


### PR DESCRIPTION
## What
Add `Makefile` to the list of files to watch for the Golang CI GitHub action.

## Why
Golang CI GitHub action runs make targets.

## Testing
none. Expect https://github.com/opendefensecloud/ocm-kit/pull/69 to run the Golang CI action afterwards.

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved
