### PR TITLE
feat: pass additional key value map to extend templating

### DIFF
--- a/cmd/ocm-kit/main.go
+++ b/cmd/ocm-kit/main.go
@@ -5,6 +5,9 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"helm.sh/helm/v4/pkg/chart/common"
+	"helm.sh/helm/v4/pkg/chart/v2/loader"
+	"helm.sh/helm/v4/pkg/strvals"
 	"ocm.software/ocm/api/ocm"
 	"ocm.software/ocm/api/ocm/extensions/repositories/ocireg"
 	"ocm.software/ocm/api/ocm/ocmutils"
@@ -17,6 +20,8 @@ func main() {
 	var (
 		chartResName            string
 		localHelmValuesTemplate string
+		setValues               []string
+		extraValuesFiles        []string
 	)
 
 	rootCmd := &cobra.Command{
@@ -81,6 +86,21 @@ It takes a component version reference and renders the first Helm values templat
 				return fmt.Errorf("failed to build rendering input: %w", err)
 			}
 
+			extra := make(map[string]any)
+			for _, f := range extraValuesFiles {
+				fileValues, err := common.ReadValuesFile(f)
+				if err != nil {
+					return fmt.Errorf("failed to parse --extra-values file %q: %w", f, err)
+				}
+				extra = loader.MergeMaps(extra, fileValues.AsMap())
+			}
+			for _, s := range setValues {
+				if err := strvals.ParseInto(s, extra); err != nil {
+					return fmt.Errorf("failed to parse --set value %q: %w", s, err)
+				}
+			}
+			input.Extra = extra
+
 			output, err := helmvalues.Render(template, input)
 			if err != nil {
 				return fmt.Errorf("failed to render helm values template: %w", err)
@@ -93,6 +113,8 @@ It takes a component version reference and renders the first Helm values templat
 
 	rootCmd.Flags().StringVarP(&chartResName, "chart-resource", "r", "", "Name of the Helm chart resource in the component to render a specific helm values template")
 	rootCmd.Flags().StringVarP(&localHelmValuesTemplate, "local-helm-values-template", "f", "", "Path to a local Helm values template file (overrides component template)")
+	rootCmd.Flags().StringArrayVar(&setValues, "set", []string{}, "Set extra template values (key=value pairs; supports auto-typing: true/false, integers, floats)")
+	rootCmd.Flags().StringArrayVar(&extraValuesFiles, "extra-values", []string{}, "Path to a YAML file with extra template values")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/helmvalues/helmvalues.go
+++ b/helmvalues/helmvalues.go
@@ -47,10 +47,12 @@ type ImageReference struct {
 }
 
 // RenderingInput contains all the data needed to render a Helm values template.
-// It provides access to component resources and the component descriptor for template processing.
+// It provides access to component resources, the component descriptor, and any
+// extra user-supplied values for template processing.
 type RenderingInput struct {
 	OCIResources map[string]ImageReference
 	Component    *compdesc.ComponentSpec
+	Extra        map[string]any
 }
 
 // RenderOption is a functional option for configuring Render behavior

--- a/helmvalues/helmvalues_test.go
+++ b/helmvalues/helmvalues_test.go
@@ -116,6 +116,107 @@ func TestRender(t *testing.T) {
 			options: []RenderOption{WithYAMLValidation()},
 			wantErr: true,
 		},
+		{
+			name: "extra string value",
+			template: &HelmValuesTemplate{
+				ResourceName:    "extra-str",
+				ResourceVersion: "1.0.0",
+				TemplateContent: `val: {{ .Extra.key }}`,
+			},
+			input: &RenderingInput{
+				Extra: map[string]any{"key": "abc"},
+			},
+			wantMatch: "val: abc",
+			wantErr:   false,
+		},
+		{
+			name: "extra bool value",
+			template: &HelmValuesTemplate{
+				ResourceName:    "extra-bool",
+				ResourceVersion: "1.0.0",
+				TemplateContent: `val: {{ .Extra.key }}`,
+			},
+			input: &RenderingInput{
+				Extra: map[string]any{"key": true},
+			},
+			wantMatch: "val: true",
+			wantErr:   false,
+		},
+		{
+			name: "extra int value",
+			template: &HelmValuesTemplate{
+				ResourceName:    "extra-int",
+				ResourceVersion: "1.0.0",
+				TemplateContent: `val: {{ .Extra.key }}`,
+			},
+			input: &RenderingInput{
+				Extra: map[string]any{"key": int64(3)},
+			},
+			wantMatch: "val: 3",
+			wantErr:   false,
+		},
+		{
+			name: "extra nested value",
+			template: &HelmValuesTemplate{
+				ResourceName:    "extra-nested",
+				ResourceVersion: "1.0.0",
+				TemplateContent: `{{ .Extra.tls.enabled }}`,
+			},
+			input: &RenderingInput{
+				Extra: map[string]any{"tls": map[string]any{"enabled": true}},
+			},
+			wantMatch: "true",
+			wantErr:   false,
+		},
+		{
+			name: "extra nil with guarded access errors",
+			template: &HelmValuesTemplate{
+				ResourceName:    "extra-guarded",
+				ResourceVersion: "1.0.0",
+				TemplateContent: `{{ if .Extra.key }}{{ .Extra.key }}{{ end }}`,
+			},
+			input: &RenderingInput{
+				Extra: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "extra nil with direct access errors",
+			template: &HelmValuesTemplate{
+				ResourceName:    "extra-direct",
+				ResourceVersion: "1.0.0",
+				TemplateContent: `{{ .Extra.key }}`,
+			},
+			input: &RenderingInput{
+				Extra: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "extra missing key errors regardless of guard",
+			template: &HelmValuesTemplate{
+				ResourceName:    "extra-missing",
+				ResourceVersion: "1.0.0",
+				TemplateContent: `{{ if .Extra.missing }}{{ .Extra.missing }}{{ end }}`,
+			},
+			input: &RenderingInput{
+				Extra: map[string]any{"other": "val"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "extra empty string renders nothing",
+			template: &HelmValuesTemplate{
+				ResourceName:    "extra-empty",
+				ResourceVersion: "1.0.0",
+				TemplateContent: `{{ if .Extra.key }}{{ .Extra.key }}{{ end }}`,
+			},
+			input: &RenderingInput{
+				Extra: map[string]any{"key": ""},
+			},
+			wantMatch: "",
+			wantErr:   false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -13,6 +13,17 @@ GO="${GO:-go}"
 VERSION="${VERSION:-"0.0.$(date +%s)"}"
 KEEP_ZOT=false
 
+cleanup() {
+	if [ "$KEEP_ZOT" = false ]; then
+		${DOCKER} stop zot-registry 2>/dev/null || true
+		${DOCKER} rm -f zot-registry 2>/dev/null || true
+		${DOCKER} volume rm zot-data 2>/dev/null || true
+	else
+		echo "Keeping zot registry running (--keep-zot flag provided)"
+	fi
+}
+trap cleanup EXIT
+
 # Parse arguments
 while [[ $# -gt 0 ]]; do
 	case $1 in
@@ -151,12 +162,17 @@ else
 	exit 1
 fi
 
-# Cleanup only if --keep-zot was not provided
-if [ "$KEEP_ZOT" = false ]; then
-	echo "Stopping zot registry..."
-	${DOCKER} stop zot-registry
-	${DOCKER} rm -f zot-registry
-	${DOCKER} volume rm zot-data
+# Test 5: Render with --extra-values and --set
+echo "Test 5: Rendering with --extra-values and --set..."
+OUTPUT5=$(${GO} run cmd/ocm-kit/main.go "http://localhost:5000/my-components//opendefense.cloud/arc:${VERSION}" -r helm-chart --local-helm-values-template "$SCRIPT_DIR/fixtures/arc/extra-test.yaml.tpl" \
+  --extra-values "$SCRIPT_DIR/fixtures/arc/extra-values.yaml" \
+  --set from_set=set-value)
+if echo "$OUTPUT5" | grep -q "from_yaml: file-value" && \
+   echo "$OUTPUT5" | grep -q "from_set: set-value"; then
+	echo "✓ Test 5 passed: Extra values rendered correctly"
 else
-	echo "Keeping zot registry running (--keep-zot flag provided)"
+	echo "✗ Test 5 failed: Extra values output missing expected content"
+	echo "Output was:"
+	echo "$OUTPUT5"
+	exit 1
 fi

--- a/test/fixtures/arc/extra-test.yaml.tpl
+++ b/test/fixtures/arc/extra-test.yaml.tpl
@@ -1,0 +1,2 @@
+from_yaml: {{ .Extra.from_yaml }}
+from_set: {{ .Extra.from_set }}

--- a/test/fixtures/arc/extra-values.yaml
+++ b/test/fixtures/arc/extra-values.yaml
@@ -1,0 +1,1 @@
+from_yaml: file-value


### PR DESCRIPTION
## What
<!-- One sentence summary -->
Closes #73

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for supplying extra template values when rendering Helm charts from the CLI.
  * Users can now pass values from YAML files and key/value pairs to influence rendered output.

* **Bug Fixes**
  * Improved handling of empty or missing extra values during template rendering.
  * Expanded coverage for nested and typed extra-value access to ensure consistent output.

* **Tests**
  * Added end-to-end coverage for rendering with extra values and command-line set inputs.
  * Expanded automated tests for additional value types and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->