### PR TITLE
test(helmvalues): use strings.Contains in assertions

### DIFF
--- a/helmvalues/helmvalues_test.go
+++ b/helmvalues/helmvalues_test.go
@@ -129,7 +129,7 @@ func TestRender(t *testing.T) {
 				return
 			}
 
-			if tt.wantMatch != "" && !contains(got, tt.wantMatch) {
+			if tt.wantMatch != "" && !strings.Contains(got, tt.wantMatch) {
 				t.Errorf("Render() output doesn't contain expected text.\nGot: %s\nExpected to contain: %s", got, tt.wantMatch)
 			}
 		})
@@ -174,10 +174,10 @@ func TestParseOCIRef(t *testing.T) {
 			}
 
 			// For valid references, check that basic parsing succeeded
-			if tt.wantTag != "" && !contains(ref, tt.wantTag) {
+			if tt.wantTag != "" && !strings.Contains(ref, tt.wantTag) {
 				t.Errorf("ParseOCIRef() tag not found. Got: %s, Expected to contain: %s", ref, tt.wantTag)
 			}
-			if tt.wantHost != "" && !contains(ref, tt.wantHost) {
+			if tt.wantHost != "" && !strings.Contains(ref, tt.wantHost) {
 				t.Errorf("ParseOCIRef() host not found. Got: %s, Expected to contain: %s", ref, tt.wantHost)
 			}
 		})
@@ -421,25 +421,6 @@ func TestRenderPullSecretFor(t *testing.T) {
 			}
 		})
 	}
-}
-
-// Helper function to check if a string contains a substring
-func contains(s, substr string) bool {
-	return len(s) > 0 && len(substr) > 0 && len(s) >= len(substr) &&
-		(s == substr || (len(s) > len(substr) &&
-			((s[:len(substr)] == substr) ||
-				(s[len(s)-len(substr):] == substr) ||
-				findSubstring(s, substr))))
-}
-
-// Helper function to find substring anywhere in the string
-func findSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }
 
 func mkImageRef(ref string) ImageReference {


### PR DESCRIPTION
## What
Just some code cleanup so we can get rid of custom functions we need to maintain in our code base. And just use what the Go toolbox already offers us.. Replace the custom `contains` / `findSubstring` helpers in the helmvalues test file with `strings.Contains` from the standard library

## Why
The test file carried its own substring search: a `contains` helper with a pile of length and prefix/suffix checks, plus a `findSubstring` loop doing the actual scan. That is exactly what `strings.Contains` already does, and it is the idiomatic way to check for a substring in Go.[^1] Re-implementing it by hand only gives us more code to read and one more place where a bug could hide (the manual index math in `findSubstring` is the classic off-by-one trap).

So this removes ~18 lines of helper code and keeps the assertions doing the same thing. `strings` was already imported in the file, so no new dependency

[^1]: `strings.Contains` reference — https://pkg.go.dev/strings#Contains

## Testing
- `go test ./helmvalues/...`  41 cases green
-  gopls or in other words my LSP confirms no leftover references to the removed helpers

## Notes for reviewers
Test-only change, no production code touched.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved