### PR TITLE
docs: note donation to NeoNephos and move to OCM community repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # ocm-kit
 
+> [!IMPORTANT]
+> **ocm-kit has moved.** The project has been donated to the NeoNephos project and now lives in the Open Component Model community repository:
+> **<https://github.com/open-component-model/community/tree/main/ocm-kit>**
+>
+> This repository is no longer the source of truth and is not maintained here anymore. Please update your dependency and any references to the new upstream location.
+
 [![Build status](https://github.com/opendefensecloud/ocm-kit/actions/workflows/golang.yaml/badge.svg)](https://github.com/opendefensecloud/ocm-kit/actions/workflows/golang.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/opendefensecloud/ocm-kit/badge.svg?branch=main)](https://coveralls.io/github/opendefensecloud/ocm-kit?branch=main)
 [![Go Report Card](https://goreportcard.com/badge/go.opendefense.cloud/ocm-kit)](https://goreportcard.com/report/go.opendefense.cloud/ocm-kit)


### PR DESCRIPTION
## What
Adds a prominent notice to the top of the README that ocm-kit has moved.

## Why
ocm-kit has been donated to the NeoNephos project and now lives in the Open Component Model community monorepo (`open-component-model/community/ocm-kit`). This repo is no longer the source of truth, so the README should point people at the new upstream location before they build against the old one. Context: opendefensecloud/solution-arsenal#710.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a prominent notice that ocm-kit has moved.
  * Directed users to the new upstream repository as the source of truth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->